### PR TITLE
#16 Fix context field on nested array

### DIFF
--- a/src/Admin/Field/ContextField.php
+++ b/src/Admin/Field/ContextField.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CleverAge/UiProcessBundle package.
+ *
+ * Copyright (c) Clever-Age
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CleverAge\UiProcessBundle\Admin\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Field\FieldTrait;
+
+class ContextField implements FieldInterface
+{
+    use FieldTrait;
+
+    public static function new(string $propertyName, ?string $label = null): self
+    {
+        return (new self())
+            ->setProperty($propertyName)
+            ->setLabel($label)
+            ->setTemplatePath('@CleverAgeUiProcess/admin/field/array.html.twig');
+    }
+}

--- a/src/Controller/Admin/LogRecordCrudController.php
+++ b/src/Controller/Admin/LogRecordCrudController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CleverAge\UiProcessBundle\Controller\Admin;
 
 use CleverAge\ProcessBundle\Configuration\ProcessConfiguration;
+use CleverAge\UiProcessBundle\Admin\Field\ContextField;
 use CleverAge\UiProcessBundle\Admin\Field\LogLevelField;
 use CleverAge\UiProcessBundle\Admin\Filter\LogProcessFilter;
 use CleverAge\UiProcessBundle\Entity\LogRecord;
@@ -23,7 +24,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Field\ArrayField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
@@ -52,8 +52,7 @@ class LogRecordCrudController extends AbstractCrudController
             LogLevelField::new('level'),
             TextField::new('message')->setMaxLength(512),
             DateTimeField::new('createdAt')->setFormat('Y/M/dd H:mm:ss'),
-            ArrayField::new('context')
-                ->setTemplatePath('@CleverAgeUiProcess/admin/field/array.html.twig')
+            ContextField::new('context')
                 ->onlyOnDetail(),
             BooleanField::new('contextIsEmpty', 'Has context info ?')
                 ->onlyOnIndex()

--- a/src/Controller/Admin/ProcessExecutionCrudController.php
+++ b/src/Controller/Admin/ProcessExecutionCrudController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CleverAge\UiProcessBundle\Controller\Admin;
 
+use CleverAge\UiProcessBundle\Admin\Field\ContextField;
 use CleverAge\UiProcessBundle\Admin\Field\EnumField;
 use CleverAge\UiProcessBundle\Entity\ProcessExecution;
 use CleverAge\UiProcessBundle\Repository\ProcessExecutionRepository;
@@ -58,7 +59,7 @@ class ProcessExecutionCrudController extends AbstractCrudController
                 return $entity->duration(); // returned format can be changed here
             }),
             ArrayField::new('report')->setTemplatePath('@CleverAgeUiProcess/admin/field/report.html.twig'),
-            ArrayField::new('context')->setTemplatePath('@CleverAgeUiProcess/admin/field/report.html.twig'),
+            ContextField::new('context'),
         ];
     }
 


### PR DESCRIPTION
When context is a nested array, process list page failed with error :

ErrorException:
Warning: Array to string conversion

  at vendor/symfony/string/AbstractUnicodeString.php:206
  at Symfony\Component\String\AbstractUnicodeString->join(array('bug' => array('bug' => 'bug')), null)
     (vendor/symfony/string/UnicodeString.php:190)
  at Symfony\Component\String\UnicodeString->join(array('bug' => array('bug' => 'bug')))
     (vendor/easycorp/easyadmin-bundle/src/Field/Configurator/ArrayConfigurator.php:46)
  at EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ArrayConfigurator->configure(object(FieldDto), object(EntityDto), object(AdminContext))
     (vendor/easycorp/easyadmin-bundle/src/Factory/FieldFactory.php:102)
  at EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory->processFields(object(EntityDto), object(FieldCollection))
     (vendor/easycorp/easyadmin-bundle/src/Factory/EntityFactory.php:43)
  at EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory->processFields(object(EntityDto), object(FieldCollection))
     (vendor/easycorp/easyadmin-bundle/src/Factory/EntityFactory.php:49)
  at EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory->processFieldsForAll(object(EntityCollection), object(FieldCollection))
     (vendor/easycorp/easyadmin-bundle/src/Controller/AbstractCrudController.php:143)
  at EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController->index(object(AdminContext))
     (vendor/symfony/http-kernel/HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:182)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php:35)
  at Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
     (vendor/autoload_runtime.php:29)
  at require_once('/var/www/vendor/autoload_runtime.php')
     (public/index.php:5) 