### PR TITLE
#21 Fix report.html.twig templating.

### DIFF
--- a/templates/admin/field/report.html.twig
+++ b/templates/admin/field/report.html.twig
@@ -2,5 +2,7 @@
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 <ul>
-  {{ field.value }}
+    {% for key, item in field.value %}
+        <li class="list-group-item"><span class="badge badge-{{ log_css_class(key) }}">{{ key }}</span> : {{ item }}</li>
+    {% endfor %}
 </ul>


### PR DESCRIPTION
## Description

After upgrade to v2.0 on ProcessExecution CRUD INDEX i have the following error

An exception has been thrown during the rendering of a template ("Warning: Array to string conversion") on report type fields.

## Requirements

* Documentation updates
  - [ ] Reference
  - [ ] Changelog
* [ ] Unit tests 

## Breaking changes