### PR TITLE
#29 Add custom_authenticator config on main firewall to use CleverAge…

### DIFF
--- a/src/DependencyInjection/CleverAgeUiProcessExtension.php
+++ b/src/DependencyInjection/CleverAgeUiProcessExtension.php
@@ -140,6 +140,7 @@ final class CleverAgeUiProcessExtension extends Extension implements PrependExte
                 'firewalls' => [
                     'main' => [
                         'provider' => 'process_user_provider',
+                        'custom_authenticator' => ['cleverage_ui_process.security.http_process_execution_authenticator'],
                         'form_login' => [
                             'login_path' => 'process_login',
                             'check_path' => 'process_login',


### PR DESCRIPTION
## Description
Add custom_authenticator config on main firewall to use CleverAge\UiProcessBundle\Security\HttpProcessExecutionAuthenticator authenticator before http_process_execute route.
<!-- Please describe the PR purpose, with references to the issues -->

## Requirements

* Documentation updates
  - [ ] Reference
  - [X] Changelog
* [ ] Unit tests 

## Breaking changes