### PR TITLE
#40 - Mise à jour de la configuration pour PHP 8.5 et ajustements divers

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-fpm-alpine
+FROM php:8.5-fpm-alpine
 
 ARG UID
 ARG GID
@@ -13,8 +13,7 @@ RUN apk update && apk add \
     bash \
     icu-dev \
     && docker-php-ext-configure intl \
-    && docker-php-ext-install intl opcache \
-    && docker-php-ext-enable opcache
+    && docker-php-ext-install intl
 
 RUN ln -s /usr/share/zoneinfo/Europe/Paris /etc/localtime \
     && sed -i "s/^;date.timezone =.*/date.timezone = Europe\/Paris/" $PHP_INI_DIR/php.ini

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,14 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
-        dependencies: [highest]
+          - '8.5'
+        dependencies: [highest, lowest]
         allowed-to-fail: [false]
         symfony-require: ['']
         variant: [normal]
         include:
-          - php-version: '8.1'
-            dependencies: highest
+          - php-version: '8.2'
+            dependencies: lowest
             allowed-to-fail: false
             symfony-require: 6.4.*
             variant: symfony/symfony:"6.4.*"
@@ -41,8 +42,8 @@ jobs:
           - php-version: '8.2'
             dependencies: highest
             allowed-to-fail: false
-            symfony-require: 7.3.*
-            variant: symfony/symfony:"7.3.*"
+            symfony-require: 7.4.*
+            variant: symfony/symfony:"7.4.*"
           - php-version: '8.3'
             dependencies: highest
             allowed-to-fail: false
@@ -51,8 +52,8 @@ jobs:
           - php-version: '8.3'
             dependencies: highest
             allowed-to-fail: false
-            symfony-require: 7.3.*
-            variant: symfony/symfony:"7.3.*"
+            symfony-require: 7.4.*
+            variant: symfony/symfony:"7.4.*"
           - php-version: '8.4'
             dependencies: highest
             allowed-to-fail: false
@@ -61,12 +62,31 @@ jobs:
           - php-version: '8.4'
             dependencies: highest
             allowed-to-fail: false
-            symfony-require: 7.3.*
-            variant: symfony/symfony:"7.3.*"
-
+            symfony-require: 7.4.*
+            variant: symfony/symfony:"7.4.*"
+          - php-version: '8.4'
+            dependencies: highest
+            allowed-to-fail: false
+            symfony-require: 8.*
+            variant: symfony/symfony:"8.*"
+          - php-version: '8.5'
+            dependencies: highest
+            allowed-to-fail: false
+            symfony-require: 6.4.*
+            variant: symfony/symfony:"6.4.*"
+          - php-version: '8.5'
+            dependencies: highest
+            allowed-to-fail: false
+            symfony-require: 7.4.*
+            variant: symfony/symfony:"7.4.*"
+          - php-version: '8.5'
+            dependencies: highest
+            allowed-to-fail: false
+            symfony-require: 8.*
+            variant: symfony/symfony:"8.*"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -24,9 +24,8 @@ $fileHeaderComment = <<<'EOF'
 
 return (new PhpCsFixer\Config())
     ->setRules([
-        '@PHP71Migration' => true,
-        '@PHP82Migration' => true,
-        '@PHPUnit75Migration:risky' => true,
+        '@PHP8x2Migration' => true,
+        '@PHPUnit7x5Migration:risky' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
         '@DoctrineAnnotation' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the CleverAge/UiProcessBundle package.
  *
@@ -34,6 +36,7 @@ return (new PhpCsFixer\Config())
         'header_comment' => ['header' => $fileHeaderComment],
         'modernize_strpos' => true,
         'get_class_to_class_keyword' => true,
+        'declare_strict_types' => true,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     {
       "name": "Xavier Marchegay",
       "email": "xmarchegay@clever-age.com",
-      "role": "Developer"
+      "role": "Lead Developer"
     }
   ],
   "autoload": {
@@ -36,24 +36,24 @@
     }
   },
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "ext-ctype": "*",
     "ext-iconv": "*",
-    "cleverage/process-bundle": "^4.0",
-    "doctrine/common": "^3.0",
-    "doctrine/dbal": "^2.9 || ^3.0",
-    "doctrine/doctrine-bundle": "^2.5",
-    "doctrine/doctrine-migrations-bundle": "^3.2",
-    "doctrine/orm": "^2.9 || ^3.0",
-    "dragonmantank/cron-expression": "^3.4",
-    "easycorp/easyadmin-bundle": "^4.8",
-    "symfony/doctrine-messenger": "^6.4|^7.3",
-    "symfony/dotenv": "^6.4|^7.3",
-    "symfony/messenger": "^6.4|^7.3",
-    "symfony/runtime": "^6.4|^7.3",
-    "symfony/scheduler": "^6.4|^7.3",
-    "symfony/string": "^6.4|^7.3",
-    "symfony/uid": "^6.4|^7.3"
+    "cleverage/process-bundle": "^5.0",
+    "doctrine/common": "^3.5",
+    "doctrine/dbal": "^3.10 || ^4.4",
+    "doctrine/doctrine-bundle": "^2.18 || ^3.1",
+    "doctrine/doctrine-migrations-bundle": "^3.7 || ^4",
+    "doctrine/orm": "^2.20 || ^3.5",
+    "dragonmantank/cron-expression": "^3.6",
+    "easycorp/easyadmin-bundle": "^4.27",
+    "symfony/doctrine-messenger": "^6.4 || ^7.4 || ^8",
+    "symfony/dotenv": "^6.4 || ^7.4 || ^8",
+    "symfony/messenger":"^6.4 || ^7.4 || ^8",
+    "symfony/runtime": "^6.4 || ^7.4 || ^8",
+    "symfony/scheduler": "^6.4 || ^7.4 || ^8",
+    "symfony/string":"^6.4 || ^7.4 || ^8",
+    "symfony/uid": "^6.4 || ^7.4 || ^8"
   },
   "require-dev": {
     "doctrine/doctrine-fixtures-bundle": "^3.4",
@@ -62,15 +62,15 @@
     "phpstan/phpstan": "*",
     "phpstan/phpstan-doctrine": "*",
     "phpstan/phpstan-symfony": "*",
-    "phpunit/phpunit": "<10.0",
+    "phpunit/phpunit": "*",
     "rector/rector": "*",
     "roave/security-advisories": "dev-latest",
-    "symfony/browser-kit": "^6.4|^7.3",
-    "symfony/css-selector": "^6.4|^7.3",
-    "symfony/debug-bundle": "^6.4|^7.3",
+    "symfony/browser-kit": "^6.4 || ^7.4 || ^8",
+    "symfony/css-selector": "^6.4 || ^7.4 || ^8",
+    "symfony/debug-bundle": "^6.4 || ^7.4 || ^8",
     "symfony/maker-bundle": "^1.31",
-    "symfony/web-profiler-bundle": "^6.4|^7.3",
-    "vincentlanglet/twig-cs-fixer": "^3.3"
+    "symfony/web-profiler-bundle": "^6.4 || ^7.4 || ^8",
+    "vincentlanglet/twig-cs-fixer": "^3.11"
   },
   "conflict": {
     "symfony/twig-bridge": "7.2.0",

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     "symfony/uid": "^6.4 || ^7.4 || ^8"
   },
   "require-dev": {
-    "doctrine/doctrine-fixtures-bundle": "^3.4",
+    "doctrine/doctrine-fixtures-bundle": "^3 || ^4",
     "friendsofphp/php-cs-fixer": "*",
     "phpstan/extension-installer": "*",
     "phpstan/phpstan": "*",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "doctrine/doctrine-migrations-bundle": "^3.7 || ^4",
     "doctrine/orm": "^2.20 || ^3.5",
     "dragonmantank/cron-expression": "^3.6",
-    "easycorp/easyadmin-bundle": "^4.27",
+    "easycorp/easyadmin-bundle": "^5",
     "symfony/doctrine-messenger": "^6.4 || ^7.4 || ^8",
     "symfony/dotenv": "^6.4 || ^7.4 || ^8",
     "symfony/messenger":"^6.4 || ^7.4 || ^8",

--- a/config/routes/easyadmin.yaml
+++ b/config/routes/easyadmin.yaml
@@ -1,0 +1,3 @@
+easyadmin:
+  resource: .
+  type: easyadmin.routes

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         cacheResultFile=".phpunit.cache/test-results"
+         cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
+         requireCoverageMetadata="true"
+         beStrictAboutCoverageMetadata="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         convertDeprecationsToExceptions="true"
          failOnRisky="true"
-         failOnWarning="true"
-         verbose="true">
+         failOnWarning="true">
     <testsuites>
         <testsuite name="default">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -8,18 +8,18 @@ use Rector\Symfony\Set\SymfonySetList;
 use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
-    ->withPhpVersion(PhpVersion::PHP_84)
+    ->withPhpVersion(PhpVersion::PHP_85)
     ->withPaths([
         __DIR__.'/src',
         __DIR__.'/tests',
     ])
-    ->withPhpSets(php81: true)
+    ->withPhpSets(php82: true)
     // here we can define, what prepared sets of rules will be applied
     ->withComposerBased(doctrine: true)
     ->withPreparedSets(deadCode: true, codeQuality: true, doctrineCodeQuality: true, symfonyCodeQuality: true)
     ->withAttributesSets(symfony: true, doctrine: true)
     ->withSets([
-        LevelSetList::UP_TO_PHP_81,
+        LevelSetList::UP_TO_PHP_85,
         SymfonySetList::SYMFONY_64,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,

--- a/rector.php
+++ b/rector.php
@@ -19,7 +19,7 @@ return RectorConfig::configure()
     ->withPreparedSets(deadCode: true, codeQuality: true, doctrineCodeQuality: true, symfonyCodeQuality: true)
     ->withAttributesSets(symfony: true, doctrine: true)
     ->withSets([
-        LevelSetList::UP_TO_PHP_85,
+        LevelSetList::UP_TO_PHP_82,
         SymfonySetList::SYMFONY_64,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,

--- a/src/Admin/Field/ContextField.php
+++ b/src/Admin/Field/ContextField.php
@@ -15,12 +15,13 @@ namespace CleverAge\UiProcessBundle\Admin\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FieldTrait;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 class ContextField implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, TranslatableInterface|string|bool|null $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Admin/Field/EnumField.php
+++ b/src/Admin/Field/EnumField.php
@@ -15,12 +15,13 @@ namespace CleverAge\UiProcessBundle\Admin\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FieldTrait;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 class EnumField implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, TranslatableInterface|string|bool|null $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Admin/Field/LogLevelField.php
+++ b/src/Admin/Field/LogLevelField.php
@@ -15,12 +15,13 @@ namespace CleverAge\UiProcessBundle\Admin\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FieldTrait;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 class LogLevelField implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, TranslatableInterface|string|bool|null $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/CleverAgeUiProcessBundle.php
+++ b/src/CleverAgeUiProcessBundle.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class CleverAgeUiProcessBundle extends Bundle
 {
+    #[\Override]
     public function getPath(): string
     {
         return \dirname(__DIR__);

--- a/src/Controller/Admin/LogRecordCrudController.php
+++ b/src/Controller/Admin/LogRecordCrudController.php
@@ -51,6 +51,7 @@ class LogRecordCrudController extends AbstractCrudController
         return LogRecord::class;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         return [
@@ -65,11 +66,13 @@ class LogRecordCrudController extends AbstractCrudController
         ];
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return $crud->showEntityActionsInlined()->setPaginatorPageSize(250);
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         return Actions::new()
@@ -85,6 +88,7 @@ class LogRecordCrudController extends AbstractCrudController
             ->add(Crud::PAGE_DETAIL, 'index');
     }
 
+    #[\Override]
     public function configureFilters(Filters $filters): Filters
     {
         $id = $this->requestStack->getMainRequest()?->query->all('filters')['process']['value'] ?? null;

--- a/src/Controller/Admin/LogRecordCrudController.php
+++ b/src/Controller/Admin/LogRecordCrudController.php
@@ -89,7 +89,7 @@ class LogRecordCrudController extends AbstractCrudController
     {
         $id = $this->requestStack->getMainRequest()?->query->all('filters')['process']['value'] ?? null;
         $processList = $this->processConfigurationsManager->getPublicProcesses();
-        $processList = array_map(fn (ProcessConfiguration $cfg) => $cfg->getCode(), $processList);
+        $processList = array_map(static fn (ProcessConfiguration $cfg) => $cfg->getCode(), $processList);
 
         return $filters->add(
             LogProcessFilter::new('Process', $processList, $id)
@@ -97,7 +97,7 @@ class LogRecordCrudController extends AbstractCrudController
             ChoiceFilter::new('level')
                 ->setTranslatableChoices(array_combine(
                     Level::VALUES,
-                    array_map(fn ($value) => 'enum.log_level.'.strtolower((string) $value), Level::NAMES)
+                    array_map(static fn ($value) => 'enum.log_level.'.strtolower((string) $value), Level::NAMES)
                 ))
                 ->setFormTypeOption('translation_domain', 'enums'),
         )->add('message')->add('context')->add('createdAt');

--- a/src/Controller/Admin/Process/LaunchAction.php
+++ b/src/Controller/Admin/Process/LaunchAction.php
@@ -50,8 +50,8 @@ class LaunchAction extends AbstractController
         ProcessConfigurationsManager $processConfigurationsManager,
         AdminContext $context,
     ): Response {
-        $processCode = $requestStack->getMainRequest()?->get('process');
-        if (null === $processCode) {
+        $processCode = (string) $requestStack->getMainRequest()?->request->get('process');
+        if ('' === $processCode) {
             throw new MissingProcessException();
         }
         $uiOptions = $processConfigurationsManager->getUiOptions($processCode);

--- a/src/Controller/Admin/Process/LaunchAction.php
+++ b/src/Controller/Admin/Process/LaunchAction.php
@@ -19,7 +19,7 @@ use CleverAge\UiProcessBundle\Form\Type\LaunchType;
 use CleverAge\UiProcessBundle\Manager\ProcessConfigurationsManager;
 use CleverAge\UiProcessBundle\Message\ProcessExecuteMessage;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
-use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -40,10 +40,7 @@ use Symfony\Component\Uid\Uuid;
 #[IsGranted('ROLE_USER')]
 class LaunchAction extends AbstractController
 {
-    /**
-     * @param AdminContext<object> $context
-     */
-    public function __construct(private readonly MessageBusInterface $messageBus, private readonly RequestStack $requestStack, private readonly ProcessConfigurationsManager $processConfigurationsManager, private readonly AdminContext $context)
+    public function __construct(private readonly MessageBusInterface $messageBus, private readonly RequestStack $requestStack, private readonly ProcessConfigurationsManager $processConfigurationsManager, private readonly AdminContextProvider $adminContextProvider)
     {
     }
 
@@ -104,7 +101,7 @@ class LaunchAction extends AbstractController
 
             return $this->redirectToRoute('process', ['routeName' => 'process_list']);
         }
-        $this->context->getAssets()->addJsAsset(Asset::fromEasyAdminAssetPackage('field-collection.js')->getAsDto());
+        $this->adminContextProvider->getContext()?->getAssets()->addJsAsset(Asset::fromEasyAdminAssetPackage('field-collection.js')->getAsDto());
 
         return $this->render(
             '@CleverAgeUiProcess/admin/process/launch.html.twig',

--- a/src/Controller/Admin/Process/LaunchAction.php
+++ b/src/Controller/Admin/Process/LaunchAction.php
@@ -40,21 +40,18 @@ use Symfony\Component\Uid\Uuid;
 #[IsGranted('ROLE_USER')]
 class LaunchAction extends AbstractController
 {
-    public function __construct(private readonly MessageBusInterface $messageBus)
+    public function __construct(private readonly MessageBusInterface $messageBus, private readonly RequestStack $requestStack, private readonly ProcessConfigurationsManager $processConfigurationsManager, private readonly AdminContext $context)
     {
     }
 
     public function __invoke(
-        RequestStack $requestStack,
         string $uploadDirectory,
-        ProcessConfigurationsManager $processConfigurationsManager,
-        AdminContext $context,
     ): Response {
-        $processCode = (string) $requestStack->getMainRequest()?->request->get('process');
+        $processCode = (string) $this->requestStack->getMainRequest()?->request->get('process');
         if ('' === $processCode) {
             throw new MissingProcessException();
         }
-        $uiOptions = $processConfigurationsManager->getUiOptions($processCode);
+        $uiOptions = $this->processConfigurationsManager->getUiOptions($processCode);
         if (null === $uiOptions) {
             throw new \InvalidArgumentException('Missing UI Options');
         }
@@ -84,7 +81,7 @@ class LaunchAction extends AbstractController
             }
             $form->setData($default);
         }
-        $form->handleRequest($requestStack->getMainRequest());
+        $form->handleRequest($this->requestStack->getMainRequest());
         if ($form->isSubmitted() && $form->isValid()) {
             $input = $form->get('input')->getData();
             if ($input instanceof UploadedFile) {
@@ -104,7 +101,7 @@ class LaunchAction extends AbstractController
 
             return $this->redirectToRoute('process', ['routeName' => 'process_list']);
         }
-        $context->getAssets()->addJsAsset(Asset::fromEasyAdminAssetPackage('field-collection.js')->getAsDto());
+        $this->context->getAssets()->addJsAsset(Asset::fromEasyAdminAssetPackage('field-collection.js')->getAsDto());
 
         return $this->render(
             '@CleverAgeUiProcess/admin/process/launch.html.twig',

--- a/src/Controller/Admin/Process/LaunchAction.php
+++ b/src/Controller/Admin/Process/LaunchAction.php
@@ -40,11 +40,12 @@ use Symfony\Component\Uid\Uuid;
 #[IsGranted('ROLE_USER')]
 class LaunchAction extends AbstractController
 {
-    public function __construct(private readonly MessageBusInterface $messageBus, private readonly RequestStack $requestStack, private readonly ProcessConfigurationsManager $processConfigurationsManager, private readonly AdminContext $context)
+    public function __construct(private readonly MessageBusInterface $messageBus, private readonly RequestStack $requestStack, private readonly ProcessConfigurationsManager $processConfigurationsManager)
     {
     }
 
     public function __invoke(
+        AdminContext $context,
         string $uploadDirectory,
     ): Response {
         $processCode = (string) $this->requestStack->getMainRequest()?->request->get('process');
@@ -101,7 +102,7 @@ class LaunchAction extends AbstractController
 
             return $this->redirectToRoute('process', ['routeName' => 'process_list']);
         }
-        $this->context->getAssets()->addJsAsset(Asset::fromEasyAdminAssetPackage('field-collection.js')->getAsDto());
+        $context->getAssets()->addJsAsset(Asset::fromEasyAdminAssetPackage('field-collection.js')->getAsDto());
 
         return $this->render(
             '@CleverAgeUiProcess/admin/process/launch.html.twig',

--- a/src/Controller/Admin/Process/LaunchAction.php
+++ b/src/Controller/Admin/Process/LaunchAction.php
@@ -127,6 +127,7 @@ class LaunchAction extends AbstractController
         $this->messageBus->dispatch($message);
     }
 
+    #[\Override]
     protected function getUser(): ?User
     {
         /** @var User $user */

--- a/src/Controller/Admin/Process/LaunchAction.php
+++ b/src/Controller/Admin/Process/LaunchAction.php
@@ -40,12 +40,14 @@ use Symfony\Component\Uid\Uuid;
 #[IsGranted('ROLE_USER')]
 class LaunchAction extends AbstractController
 {
-    public function __construct(private readonly MessageBusInterface $messageBus, private readonly RequestStack $requestStack, private readonly ProcessConfigurationsManager $processConfigurationsManager)
+    /**
+     * @param AdminContext<object> $context
+     */
+    public function __construct(private readonly MessageBusInterface $messageBus, private readonly RequestStack $requestStack, private readonly ProcessConfigurationsManager $processConfigurationsManager, private readonly AdminContext $context)
     {
     }
 
     public function __invoke(
-        AdminContext $context,
         string $uploadDirectory,
     ): Response {
         $processCode = (string) $this->requestStack->getMainRequest()?->query->get('process');
@@ -102,7 +104,7 @@ class LaunchAction extends AbstractController
 
             return $this->redirectToRoute('process', ['routeName' => 'process_list']);
         }
-        $context->getAssets()->addJsAsset(Asset::fromEasyAdminAssetPackage('field-collection.js')->getAsDto());
+        $this->context->getAssets()->addJsAsset(Asset::fromEasyAdminAssetPackage('field-collection.js')->getAsDto());
 
         return $this->render(
             '@CleverAgeUiProcess/admin/process/launch.html.twig',

--- a/src/Controller/Admin/Process/LaunchAction.php
+++ b/src/Controller/Admin/Process/LaunchAction.php
@@ -48,7 +48,7 @@ class LaunchAction extends AbstractController
         AdminContext $context,
         string $uploadDirectory,
     ): Response {
-        $processCode = (string) $this->requestStack->getMainRequest()?->request->get('process');
+        $processCode = (string) $this->requestStack->getMainRequest()?->query->get('process');
         if ('' === $processCode) {
             throw new MissingProcessException();
         }

--- a/src/Controller/Admin/Process/ListAction.php
+++ b/src/Controller/Admin/Process/ListAction.php
@@ -24,16 +24,16 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_USER')]
 class ListAction extends AbstractController
 {
-    public function __construct(private readonly IntlFormatterInterface $intlFormatter)
+    public function __construct(private readonly IntlFormatterInterface $intlFormatter, private readonly ProcessConfigurationsManager $processConfigurationsManager)
     {
     }
 
-    public function __invoke(ProcessConfigurationsManager $processConfigurationsManager): Response
+    public function __invoke(): Response
     {
         return $this->render(
             '@CleverAgeUiProcess/admin/process/list.html.twig',
             [
-                'processes' => $processConfigurationsManager->getPublicProcesses(),
+                'processes' => $this->processConfigurationsManager->getPublicProcesses(),
                 'IntlFormatterService' => $this->intlFormatter,
             ]
         );

--- a/src/Controller/Admin/Process/UploadAndExecuteAction.php
+++ b/src/Controller/Admin/Process/UploadAndExecuteAction.php
@@ -49,7 +49,7 @@ class UploadAndExecuteAction extends AbstractController
         $form = $this->createForm(
             ProcessUploadFileType::class,
             null,
-            ['process_code' => $requestStack->getMainRequest()?->get('process')]
+            ['process_code' => $requestStack->getMainRequest()?->request->get('process')]
         );
         $form->handleRequest($requestStack->getMainRequest());
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Controller/Admin/Process/UploadAndExecuteAction.php
+++ b/src/Controller/Admin/Process/UploadAndExecuteAction.php
@@ -37,9 +37,11 @@ use Symfony\Component\Uid\Uuid;
 #[IsGranted('ROLE_USER')]
 class UploadAndExecuteAction extends AbstractController
 {
+    public function __construct(private readonly RequestStack $requestStack, private readonly MessageBusInterface $messageBus)
+    {
+    }
+
     public function __invoke(
-        RequestStack $requestStack,
-        MessageBusInterface $messageBus,
         string $uploadDirectory,
         #[ValueResolver('process')] ProcessConfiguration $processConfiguration,
     ): Response {
@@ -49,15 +51,15 @@ class UploadAndExecuteAction extends AbstractController
         $form = $this->createForm(
             ProcessUploadFileType::class,
             null,
-            ['process_code' => $requestStack->getMainRequest()?->request->get('process')]
+            ['process_code' => $this->requestStack->getMainRequest()?->request->get('process')]
         );
-        $form->handleRequest($requestStack->getMainRequest());
+        $form->handleRequest($this->requestStack->getMainRequest());
         if ($form->isSubmitted() && $form->isValid()) {
             /** @var UploadedFile $file */
             $file = $form->getData();
             $savedFilepath = \sprintf('%s/%s.%s', $uploadDirectory, Uuid::v4(), $file->getClientOriginalExtension());
             (new Filesystem())->dumpFile($savedFilepath, $file->getContent());
-            $messageBus->dispatch(
+            $this->messageBus->dispatch(
                 new ProcessExecuteMessage(
                     $form->getConfig()->getOption('process_code'),
                     $savedFilepath

--- a/src/Controller/Admin/ProcessDashboardController.php
+++ b/src/Controller/Admin/ProcessDashboardController.php
@@ -13,21 +13,19 @@ declare(strict_types=1);
 
 namespace CleverAge\UiProcessBundle\Controller\Admin;
 
-use CleverAge\UiProcessBundle\Entity\LogRecord;
-use CleverAge\UiProcessBundle\Entity\ProcessExecution;
-use CleverAge\UiProcessBundle\Entity\ProcessSchedule;
 use CleverAge\UiProcessBundle\Entity\User;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Translation\LocaleSwitcher;
 
 #[IsGranted('ROLE_USER')]
+#[AdminDashboard(routePath: '/process', routeName: 'process')]
 class ProcessDashboardController extends AbstractDashboardController
 {
     public function __construct(
@@ -36,7 +34,6 @@ class ProcessDashboardController extends AbstractDashboardController
     ) {
     }
 
-    #[Route('/process', name: 'process')]
     public function index(): Response
     {
         $adminUrlGenerator = $this->container->get(AdminUrlGenerator::class);
@@ -57,15 +54,15 @@ class ProcessDashboardController extends AbstractDashboardController
         yield MenuItem::subMenu('Process', 'fas fa-gear')->setSubItems(
             [
                 MenuItem::linkToRoute('Process list', 'fas fa-list', 'process_list'),
-                MenuItem::linkToCrud('Executions', 'fas fa-rocket', ProcessExecution::class),
-                MenuItem::linkToCrud('Logs', 'fas fa-pen', LogRecord::class),
-                MenuItem::linkToCrud('Scheduler', 'fas fa-solid fa-clock', ProcessSchedule::class),
+                MenuItem::linkTo(ProcessExecutionCrudController::class, 'Executions', 'fas fa-rocket'),
+                MenuItem::linkTo(LogRecordCrudController::class, 'Logs', 'fas fa-pen'),
+                MenuItem::linkTo(ProcessScheduleCrudController::class, 'Scheduler', 'fas fa-solid fa-clock'),
             ]
         );
         if ($this->isGranted('ROLE_ADMIN')) {
             yield MenuItem::subMenu('Users', 'fas fa-user')->setSubItems(
                 [
-                    MenuItem::linkToCrud('User List', 'fas fa-user', User::class),
+                    MenuItem::linkTo(UserCrudController::class, 'User List', 'fas fa-user'),
                 ]
             );
         }

--- a/src/Controller/Admin/ProcessDashboardController.php
+++ b/src/Controller/Admin/ProcessDashboardController.php
@@ -34,6 +34,7 @@ class ProcessDashboardController extends AbstractDashboardController
     ) {
     }
 
+    #[\Override]
     public function index(): Response
     {
         $adminUrlGenerator = $this->container->get(AdminUrlGenerator::class);
@@ -41,6 +42,7 @@ class ProcessDashboardController extends AbstractDashboardController
         return $this->redirect($adminUrlGenerator->setController(ProcessExecutionCrudController::class)->generateUrl());
     }
 
+    #[\Override]
     public function configureDashboard(): Dashboard
     {
         return Dashboard::new()
@@ -48,6 +50,7 @@ class ProcessDashboardController extends AbstractDashboardController
             ->setTitle('<img src="'.$this->logoPath.'" />');
     }
 
+    #[\Override]
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linkToDashboard('Dashboard', 'fa fa-home');
@@ -68,6 +71,7 @@ class ProcessDashboardController extends AbstractDashboardController
         }
     }
 
+    #[\Override]
     public function configureCrud(): Crud
     {
         /** @var ?User $user */

--- a/src/Controller/Admin/ProcessExecutionCrudController.php
+++ b/src/Controller/Admin/ProcessExecutionCrudController.php
@@ -18,6 +18,7 @@ use CleverAge\UiProcessBundle\Admin\Field\EnumField;
 use CleverAge\UiProcessBundle\Admin\Filter\ProcessExecutionDurationFilter;
 use CleverAge\UiProcessBundle\Entity\ProcessExecution;
 use CleverAge\UiProcessBundle\Repository\ProcessExecutionRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -108,6 +109,7 @@ class ProcessExecutionCrudController extends AbstractCrudController
             );
     }
 
+    #[AdminRoute('show-logs', 'show-logs')]
     public function showLogs(): RedirectResponse
     {
         /** @var AdminUrlGenerator $adminUrlGenerator */
@@ -132,6 +134,7 @@ class ProcessExecutionCrudController extends AbstractCrudController
         return $this->redirect($url);
     }
 
+    #[AdminRoute('download-logs', 'download-logs')]
     public function downloadLogFile(): Response
     {
         /** @var ProcessExecution $processExecution */

--- a/src/Controller/Admin/ProcessExecutionCrudController.php
+++ b/src/Controller/Admin/ProcessExecutionCrudController.php
@@ -46,6 +46,7 @@ class ProcessExecutionCrudController extends AbstractCrudController
         private readonly ProcessExecutionRepository $processExecutionRepository,
         private readonly string $logDirectory,
         private readonly TranslatorInterface $translator,
+        private readonly AdminContext $context,
     ) {
     }
 
@@ -109,7 +110,7 @@ class ProcessExecutionCrudController extends AbstractCrudController
             );
     }
 
-    public function showLogs(AdminContext $adminContext): RedirectResponse
+    public function showLogs(): RedirectResponse
     {
         /** @var AdminUrlGenerator $adminUrlGenerator */
         $adminUrlGenerator = $this->container->get(AdminUrlGenerator::class);
@@ -133,11 +134,10 @@ class ProcessExecutionCrudController extends AbstractCrudController
         return $this->redirect($url);
     }
 
-    public function downloadLogFile(
-        AdminContext $context,
-    ): Response {
+    public function downloadLogFile(): Response
+    {
         /** @var ProcessExecution $processExecution */
-        $processExecution = $context->getEntity()->getInstance();
+        $processExecution = $this->context->getEntity()->getInstance();
         $filepath = $this->getLogFilePath($processExecution);
         $basename = basename($filepath);
         $content = file_get_contents($filepath);

--- a/src/Controller/Admin/ProcessExecutionCrudController.php
+++ b/src/Controller/Admin/ProcessExecutionCrudController.php
@@ -42,10 +42,14 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[IsGranted('ROLE_USER')]
 class ProcessExecutionCrudController extends AbstractCrudController
 {
+    /**
+     * @param AdminContext<object> $context
+     */
     public function __construct(
         private readonly ProcessExecutionRepository $processExecutionRepository,
         private readonly string $logDirectory,
         private readonly TranslatorInterface $translator,
+        private readonly AdminContext $context,
     ) {
     }
 
@@ -133,10 +137,10 @@ class ProcessExecutionCrudController extends AbstractCrudController
         return $this->redirect($url);
     }
 
-    public function downloadLogFile(AdminContext $context): Response
+    public function downloadLogFile(): Response
     {
         /** @var ProcessExecution $processExecution */
-        $processExecution = $context->getEntity()->getInstance();
+        $processExecution = $this->context->getEntity()->getInstance();
         $filepath = $this->getLogFilePath($processExecution);
         $basename = basename($filepath);
         $content = file_get_contents($filepath);

--- a/src/Controller/Admin/ProcessExecutionCrudController.php
+++ b/src/Controller/Admin/ProcessExecutionCrudController.php
@@ -135,7 +135,7 @@ class ProcessExecutionCrudController extends AbstractCrudController
     public function downloadLogFile(): Response
     {
         /** @var ProcessExecution $processExecution */
-        $processExecution = $this->getContext()->getEntity()->getInstance();
+        $processExecution = $this->getContext()?->getEntity()->getInstance();
         $filepath = $this->getLogFilePath($processExecution);
         $basename = basename($filepath);
         $content = file_get_contents($filepath);

--- a/src/Controller/Admin/ProcessExecutionCrudController.php
+++ b/src/Controller/Admin/ProcessExecutionCrudController.php
@@ -54,6 +54,7 @@ class ProcessExecutionCrudController extends AbstractCrudController
         return ProcessExecution::class;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         return [
@@ -71,6 +72,7 @@ class ProcessExecutionCrudController extends AbstractCrudController
         ];
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         $crud->showEntityActionsInlined();
@@ -79,6 +81,7 @@ class ProcessExecutionCrudController extends AbstractCrudController
         return $crud;
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         return Actions::new()
@@ -152,6 +155,7 @@ class ProcessExecutionCrudController extends AbstractCrudController
         return $response;
     }
 
+    #[\Override]
     public function configureFilters(Filters $filters): Filters
     {
         return $filters

--- a/src/Controller/Admin/ProcessExecutionCrudController.php
+++ b/src/Controller/Admin/ProcessExecutionCrudController.php
@@ -22,7 +22,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
-use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ArrayField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
@@ -42,14 +41,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[IsGranted('ROLE_USER')]
 class ProcessExecutionCrudController extends AbstractCrudController
 {
-    /**
-     * @param AdminContext<object> $context
-     */
     public function __construct(
         private readonly ProcessExecutionRepository $processExecutionRepository,
         private readonly string $logDirectory,
         private readonly TranslatorInterface $translator,
-        private readonly AdminContext $context,
     ) {
     }
 
@@ -140,7 +135,7 @@ class ProcessExecutionCrudController extends AbstractCrudController
     public function downloadLogFile(): Response
     {
         /** @var ProcessExecution $processExecution */
-        $processExecution = $this->context->getEntity()->getInstance();
+        $processExecution = $this->getContext()->getEntity()->getInstance();
         $filepath = $this->getLogFilePath($processExecution);
         $basename = basename($filepath);
         $content = file_get_contents($filepath);

--- a/src/Controller/Admin/ProcessExecutionCrudController.php
+++ b/src/Controller/Admin/ProcessExecutionCrudController.php
@@ -46,7 +46,6 @@ class ProcessExecutionCrudController extends AbstractCrudController
         private readonly ProcessExecutionRepository $processExecutionRepository,
         private readonly string $logDirectory,
         private readonly TranslatorInterface $translator,
-        private readonly AdminContext $context,
     ) {
     }
 
@@ -134,10 +133,10 @@ class ProcessExecutionCrudController extends AbstractCrudController
         return $this->redirect($url);
     }
 
-    public function downloadLogFile(): Response
+    public function downloadLogFile(AdminContext $context): Response
     {
         /** @var ProcessExecution $processExecution */
-        $processExecution = $this->context->getEntity()->getInstance();
+        $processExecution = $context->getEntity()->getInstance();
         $filepath = $this->getLogFilePath($processExecution);
         $basename = basename($filepath);
         $content = file_get_contents($filepath);

--- a/src/Controller/Admin/ProcessScheduleCrudController.php
+++ b/src/Controller/Admin/ProcessScheduleCrudController.php
@@ -57,13 +57,13 @@ class ProcessScheduleCrudController extends AbstractCrudController
     public function configureActions(Actions $actions): Actions
     {
         return $actions
-            ->update(Crud::PAGE_INDEX, Action::NEW, fn (Action $action) => $action->setIcon('fa fa-plus')
+            ->update(Crud::PAGE_INDEX, Action::NEW, static fn (Action $action) => $action->setIcon('fa fa-plus')
                 ->setLabel(false)
-                ->addCssClass(''))->update(Crud::PAGE_INDEX, Action::EDIT, fn (Action $action) => $action->setIcon('fa fa-edit')
+                ->addCssClass(''))->update(Crud::PAGE_INDEX, Action::EDIT, static fn (Action $action) => $action->setIcon('fa fa-edit')
                 ->setLabel(false)
-                ->addCssClass('text-warning'))->update(Crud::PAGE_INDEX, Action::DELETE, fn (Action $action) => $action->setIcon('fa fa-trash-o')
+                ->addCssClass('text-warning'))->update(Crud::PAGE_INDEX, Action::DELETE, static fn (Action $action) => $action->setIcon('fa fa-trash-o')
                 ->setLabel(false)
-                ->addCssClass(''))->update(Crud::PAGE_INDEX, Action::BATCH_DELETE, fn (Action $action) => $action->setLabel('Delete')
+                ->addCssClass(''))->update(Crud::PAGE_INDEX, Action::BATCH_DELETE, static fn (Action $action) => $action->setLabel('Delete')
                 ->addCssClass(''));
     }
 
@@ -74,7 +74,7 @@ class ProcessScheduleCrudController extends AbstractCrudController
 
     public function configureFields(string $pageName): iterable
     {
-        $choices = array_map(fn (ProcessConfiguration $configuration) => [$configuration->getCode()], $this->processConfigurationsManager->getPublicProcesses());
+        $choices = array_map(static fn (ProcessConfiguration $configuration) => [$configuration->getCode()], $this->processConfigurationsManager->getPublicProcesses());
 
         return [
             FormField::addTab('General'),
@@ -90,7 +90,7 @@ class ProcessScheduleCrudController extends AbstractCrudController
                 ->setVirtual(true)
                 ->hideOnForm()
                 ->hideOnDetail()
-                ->formatValue(fn ($value, ProcessSchedule $entity) => ProcessScheduleType::CRON === $entity->getType()
+                ->formatValue(static fn ($value, ProcessSchedule $entity) => ProcessScheduleType::CRON === $entity->getType()
                     ? CronExpressionTrigger::fromSpec($entity->getExpression() ?? '')
                         ->getNextRunDate(new \DateTimeImmutable())
                         ?->format('c')

--- a/src/Controller/Admin/ProcessScheduleCrudController.php
+++ b/src/Controller/Admin/ProcessScheduleCrudController.php
@@ -47,6 +47,7 @@ class ProcessScheduleCrudController extends AbstractCrudController
     {
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return parent::configureCrud($crud)
@@ -54,6 +55,7 @@ class ProcessScheduleCrudController extends AbstractCrudController
             ->showEntityActionsInlined();
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         return $actions
@@ -72,6 +74,7 @@ class ProcessScheduleCrudController extends AbstractCrudController
         return ProcessSchedule::class;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         $choices = array_map(static fn (ProcessConfiguration $configuration) => [$configuration->getCode()], $this->processConfigurationsManager->getPublicProcesses());
@@ -107,6 +110,7 @@ class ProcessScheduleCrudController extends AbstractCrudController
         ];
     }
 
+    #[\Override]
     public function index(AdminContext $context): KeyValueStore|RedirectResponse|Response
     {
         if (false === $this->schedulerIsRunning()) {

--- a/src/Controller/Admin/Security/LogoutController.php
+++ b/src/Controller/Admin/Security/LogoutController.php
@@ -20,10 +20,14 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class LogoutController extends AbstractController
 {
-    #[Route('/process/logout', name: 'process_logout')]
-    public function __invoke(Security $security): Response
+    public function __construct(private readonly Security $security)
     {
-        $security->logout();
+    }
+
+    #[Route('/process/logout', name: 'process_logout')]
+    public function __invoke(): Response
+    {
+        $this->security->logout();
 
         return $this->redirectToRoute('process_login');
     }

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -17,7 +17,6 @@ use CleverAge\UiProcessBundle\Entity\User;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
-use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\EmailField;
@@ -42,9 +41,8 @@ class UserCrudController extends AbstractCrudController
 {
     /**
      * @param array<string, string> $roles
-     * @param AdminContext<object>  $adminContext
      */
-    public function __construct(private readonly array $roles, private readonly AdminUrlGenerator $adminUrlGenerator, private readonly AdminContext $adminContext)
+    public function __construct(private readonly array $roles, private readonly AdminUrlGenerator $adminUrlGenerator)
     {
     }
 
@@ -108,12 +106,13 @@ class UserCrudController extends AbstractCrudController
 
     public function generateToken(): Response
     {
+        $adminContext = $this->getContext();
         /** @var User $user */
-        $user = $this->adminContext->getEntity()->getInstance();
+        $user = $adminContext->getEntity()->getInstance();
         $token = md5(uniqid(date('YmdHis')));
         $user->setToken((new Pbkdf2PasswordHasher())->hash($token));
         $this->persistEntity(
-            $this->container->get('doctrine')->getManagerForClass($this->adminContext->getEntity()->getFqcn()),
+            $this->container->get('doctrine')->getManagerForClass($adminContext->getEntity()->getFqcn()),
             $user
         );
         $this->addFlash('success', 'New token generated '.$token.' (keep it in secured area. This token will never be displayed anymore)');

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -41,7 +41,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class UserCrudController extends AbstractCrudController
 {
     /** @param array<string, string> $roles */
-    public function __construct(private readonly array $roles)
+    public function __construct(private readonly array $roles, private readonly AdminContext $adminContext, private readonly AdminUrlGenerator $adminUrlGenerator)
     {
     }
 
@@ -103,20 +103,20 @@ class UserCrudController extends AbstractCrudController
                 ->addCssClass(''))->add(Crud::PAGE_EDIT, Action::new('generateToken')->linkToCrudAction('generateToken'));
     }
 
-    public function generateToken(AdminContext $adminContext, AdminUrlGenerator $adminUrlGenerator): Response
+    public function generateToken(): Response
     {
         /** @var User $user */
-        $user = $adminContext->getEntity()->getInstance();
+        $user = $this->adminContext->getEntity()->getInstance();
         $token = md5(uniqid(date('YmdHis')));
         $user->setToken((new Pbkdf2PasswordHasher())->hash($token));
         $this->persistEntity(
-            $this->container->get('doctrine')->getManagerForClass($adminContext->getEntity()->getFqcn()),
+            $this->container->get('doctrine')->getManagerForClass($this->adminContext->getEntity()->getFqcn()),
             $user
         );
         $this->addFlash('success', 'New token generated '.$token.' (keep it in secured area. This token will never be displayed anymore)');
 
         return $this->redirect(
-            $adminUrlGenerator
+            $this->adminUrlGenerator
                 ->setController(self::class)
                 ->setAction(Action::EDIT)
                 ->setEntityId($user->getId())

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -108,11 +108,11 @@ class UserCrudController extends AbstractCrudController
     {
         $adminContext = $this->getContext();
         /** @var User $user */
-        $user = $adminContext->getEntity()->getInstance();
+        $user = $adminContext?->getEntity()->getInstance();
         $token = md5(uniqid(date('YmdHis')));
         $user->setToken((new Pbkdf2PasswordHasher())->hash($token));
         $this->persistEntity(
-            $this->container->get('doctrine')->getManagerForClass($adminContext->getEntity()->getFqcn()),
+            $this->container->get('doctrine')->getManagerForClass($adminContext?->getEntity()->getFqcn()),
             $user
         );
         $this->addFlash('success', 'New token generated '.$token.' (keep it in secured area. This token will never be displayed anymore)');

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -47,6 +47,7 @@ class UserCrudController extends AbstractCrudController
     {
     }
 
+    #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         $crud->showEntityActionsInlined();
@@ -60,6 +61,7 @@ class UserCrudController extends AbstractCrudController
         return User::class;
     }
 
+    #[\Override]
     public function configureFields(string $pageName): iterable
     {
         yield FormField::addTab('Credentials')->setIcon('fa fa-key');
@@ -92,6 +94,7 @@ class UserCrudController extends AbstractCrudController
         yield LocaleField::new('locale');
     }
 
+    #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         return $actions

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CleverAge\UiProcessBundle\Controller\Admin;
 
 use CleverAge\UiProcessBundle\Entity\User;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -104,6 +105,7 @@ class UserCrudController extends AbstractCrudController
                 ->addCssClass(''))->add(Crud::PAGE_EDIT, Action::new('generateToken')->linkToCrudAction('generateToken'));
     }
 
+    #[AdminRoute(path: '{id}/generate-token', name: 'generateToken')]
     public function generateToken(): Response
     {
         $adminContext = $this->getContext();

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -41,7 +41,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class UserCrudController extends AbstractCrudController
 {
     /** @param array<string, string> $roles */
-    public function __construct(private readonly array $roles, private readonly AdminContext $adminContext, private readonly AdminUrlGenerator $adminUrlGenerator)
+    public function __construct(private readonly array $roles, private readonly AdminUrlGenerator $adminUrlGenerator)
     {
     }
 
@@ -103,14 +103,14 @@ class UserCrudController extends AbstractCrudController
                 ->addCssClass(''))->add(Crud::PAGE_EDIT, Action::new('generateToken')->linkToCrudAction('generateToken'));
     }
 
-    public function generateToken(): Response
+    public function generateToken(AdminContext $adminContext): Response
     {
         /** @var User $user */
-        $user = $this->adminContext->getEntity()->getInstance();
+        $user = $adminContext->getEntity()->getInstance();
         $token = md5(uniqid(date('YmdHis')));
         $user->setToken((new Pbkdf2PasswordHasher())->hash($token));
         $this->persistEntity(
-            $this->container->get('doctrine')->getManagerForClass($this->adminContext->getEntity()->getFqcn()),
+            $this->container->get('doctrine')->getManagerForClass($adminContext->getEntity()->getFqcn()),
             $user
         );
         $this->addFlash('success', 'New token generated '.$token.' (keep it in secured area. This token will never be displayed anymore)');

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -40,8 +40,11 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_USER')]
 class UserCrudController extends AbstractCrudController
 {
-    /** @param array<string, string> $roles */
-    public function __construct(private readonly array $roles, private readonly AdminUrlGenerator $adminUrlGenerator)
+    /**
+     * @param array<string, string> $roles
+     * @param AdminContext<object>  $adminContext
+     */
+    public function __construct(private readonly array $roles, private readonly AdminUrlGenerator $adminUrlGenerator, private readonly AdminContext $adminContext)
     {
     }
 
@@ -93,24 +96,24 @@ class UserCrudController extends AbstractCrudController
     public function configureActions(Actions $actions): Actions
     {
         return $actions
-            ->update(Crud::PAGE_INDEX, Action::NEW, fn (Action $action) => $action->setIcon('fa fa-plus')
+            ->update(Crud::PAGE_INDEX, Action::NEW, static fn (Action $action) => $action->setIcon('fa fa-plus')
                 ->setLabel(false)
-                ->addCssClass(''))->update(Crud::PAGE_INDEX, Action::EDIT, fn (Action $action) => $action->setIcon('fa fa-edit')
+                ->addCssClass(''))->update(Crud::PAGE_INDEX, Action::EDIT, static fn (Action $action) => $action->setIcon('fa fa-edit')
                 ->setLabel(false)
-                ->addCssClass('text-warning'))->update(Crud::PAGE_INDEX, Action::DELETE, fn (Action $action) => $action->setIcon('fa fa-trash-o')
+                ->addCssClass('text-warning'))->update(Crud::PAGE_INDEX, Action::DELETE, static fn (Action $action) => $action->setIcon('fa fa-trash-o')
                 ->setLabel(false)
-                ->addCssClass(''))->update(Crud::PAGE_INDEX, Action::BATCH_DELETE, fn (Action $action) => $action->setLabel('Delete')
+                ->addCssClass(''))->update(Crud::PAGE_INDEX, Action::BATCH_DELETE, static fn (Action $action) => $action->setLabel('Delete')
                 ->addCssClass(''))->add(Crud::PAGE_EDIT, Action::new('generateToken')->linkToCrudAction('generateToken'));
     }
 
-    public function generateToken(AdminContext $adminContext): Response
+    public function generateToken(): Response
     {
         /** @var User $user */
-        $user = $adminContext->getEntity()->getInstance();
+        $user = $this->adminContext->getEntity()->getInstance();
         $token = md5(uniqid(date('YmdHis')));
         $user->setToken((new Pbkdf2PasswordHasher())->hash($token));
         $this->persistEntity(
-            $this->container->get('doctrine')->getManagerForClass($adminContext->getEntity()->getFqcn()),
+            $this->container->get('doctrine')->getManagerForClass($this->adminContext->getEntity()->getFqcn()),
             $user
         );
         $this->addFlash('success', 'New token generated '.$token.' (keep it in secured area. This token will never be displayed anymore)');

--- a/src/Controller/ProcessExecuteController.php
+++ b/src/Controller/ProcessExecuteController.php
@@ -28,13 +28,14 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 #[Route(path: '/http/process/execute', name: 'http_process_execute', methods: ['POST'])]
 class ProcessExecuteController extends AbstractController
 {
+    public function __construct(private readonly ValidatorInterface $validator, private readonly MessageBusInterface $bus, private readonly ProcessManager $processManager)
+    {
+    }
+
     public function __invoke(
         #[ValueResolver('http_process_execution')] HttpProcessExecution $httpProcessExecution,
-        ValidatorInterface $validator,
-        MessageBusInterface $bus,
-        ProcessManager $processManager,
     ): JsonResponse {
-        $violations = $validator->validate($httpProcessExecution);
+        $violations = $this->validator->validate($httpProcessExecution);
         if ($violations->count() > 0) {
             $violationsMessages = [];
             foreach ($violations as $violation) {
@@ -43,7 +44,7 @@ class ProcessExecuteController extends AbstractController
             throw new UnprocessableEntityHttpException(implode('. ', $violationsMessages));
         }
         if ($httpProcessExecution->queue) {
-            $bus->dispatch(
+            $this->bus->dispatch(
                 new ProcessExecuteMessage(
                     $httpProcessExecution->code ?? '',
                     $httpProcessExecution->input,
@@ -56,7 +57,7 @@ class ProcessExecuteController extends AbstractController
             return new JsonResponse('Process has been added to queue. It will start as soon as possible.');
         } else {
             try {
-                $processManager->execute(
+                $this->processManager->execute(
                     $httpProcessExecution->code ?? '',
                     $httpProcessExecution->input,
                     \is_string($httpProcessExecution->context)

--- a/src/Controller/ProcessExecuteController.php
+++ b/src/Controller/ProcessExecuteController.php
@@ -55,20 +55,19 @@ class ProcessExecuteController extends AbstractController
             );
 
             return new JsonResponse('Process has been added to queue. It will start as soon as possible.');
-        } else {
-            try {
-                $this->processManager->execute(
-                    $httpProcessExecution->code ?? '',
-                    $httpProcessExecution->input,
-                    \is_string($httpProcessExecution->context)
-                        ? json_decode($httpProcessExecution->context, true)
-                        : $httpProcessExecution->context
-                );
-            } catch (\Throwable $e) {
-                return new JsonResponse($e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
-            }
-
-            return new JsonResponse('Process has been proceed well.');
         }
+        try {
+            $this->processManager->execute(
+                $httpProcessExecution->code ?? '',
+                $httpProcessExecution->input,
+                \is_string($httpProcessExecution->context)
+                    ? json_decode($httpProcessExecution->context, true)
+                    : $httpProcessExecution->context
+            );
+        } catch (\Throwable $e) {
+            return new JsonResponse($e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return new JsonResponse('Process has been proceed well.');
     }
 }

--- a/src/Entity/LogRecord.php
+++ b/src/Entity/LogRecord.php
@@ -65,4 +65,9 @@ class LogRecord
     {
         return [] !== $this->context;
     }
+
+    public function getProcessExecution(): ProcessExecution
+    {
+        return $this->processExecution;
+    }
 }

--- a/src/Entity/LogRecord.php
+++ b/src/Entity/LogRecord.php
@@ -51,7 +51,7 @@ class LogRecord
     public function __construct(
         \Monolog\LogRecord $record,
         #[ORM\ManyToOne(targetEntity: ProcessExecution::class, cascade: ['all'])]
-        #[ORM\JoinColumn(name: 'process_execution_id', referencedColumnName: 'id', onDelete: 'CASCADE', nullable: false)]
+        #[ORM\JoinColumn(name: 'process_execution_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
         private readonly ProcessExecution $processExecution,
     ) {
         $this->channel = (string) (new UnicodeString($record->channel))->truncate(64);

--- a/src/Entity/LogRecord.php
+++ b/src/Entity/LogRecord.php
@@ -58,7 +58,7 @@ class LogRecord
         $this->level = $record->level->value;
         $this->message = (string) (new UnicodeString($record->message))->truncate(512);
         $this->context = $record->context;
-        $this->createdAt = \DateTimeImmutable::createFromMutable(new \DateTime());
+        $this->createdAt = $record->datetime;
     }
 
     public function contextIsEmpty(): bool

--- a/src/Entity/ProcessSchedule.php
+++ b/src/Entity/ProcessSchedule.php
@@ -87,12 +87,7 @@ class ProcessSchedule
         $this->context = $context;
     }
 
-    /**
-     * PHP 8.1 Fatal error: Null can not be used as a standalone type.
-     *
-     * @phpstan-ignore missingType.return
-     */
-    public function getNextExecution()
+    public function getNextExecution(): null
     {
         return null;
     }

--- a/src/EventSubscriber/ProcessEventSubscriber.php
+++ b/src/EventSubscriber/ProcessEventSubscriber.php
@@ -22,15 +22,12 @@ use CleverAge\UiProcessBundle\Monolog\Handler\ProcessHandler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Uid\Uuid;
 
-/**
- * PHP 8.2 : Replace by readonly class.
- */
-final class ProcessEventSubscriber implements EventSubscriberInterface
+readonly final class ProcessEventSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ProcessHandler $processHandler,
-        private readonly DoctrineProcessHandler $doctrineProcessHandler,
-        private readonly ProcessExecutionManager $processExecutionManager,
+        private ProcessHandler $processHandler,
+        private DoctrineProcessHandler $doctrineProcessHandler,
+        private ProcessExecutionManager $processExecutionManager,
     ) {
     }
 

--- a/src/EventSubscriber/ProcessEventSubscriber.php
+++ b/src/EventSubscriber/ProcessEventSubscriber.php
@@ -22,7 +22,7 @@ use CleverAge\UiProcessBundle\Monolog\Handler\ProcessHandler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Uid\Uuid;
 
-readonly final class ProcessEventSubscriber implements EventSubscriberInterface
+final readonly class ProcessEventSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private ProcessHandler $processHandler,

--- a/src/Form/Type/LaunchType.php
+++ b/src/Form/Type/LaunchType.php
@@ -69,6 +69,7 @@ class LaunchType extends AbstractType
         $resolver->setRequired('process_code');
     }
 
+    #[\Override]
     public function getParent(): string
     {
         return FormType::class;

--- a/src/Form/Type/LaunchType.php
+++ b/src/Form/Type/LaunchType.php
@@ -59,8 +59,8 @@ class LaunchType extends AbstractType
             ]
         );
         $builder->get('context')->addModelTransformer(new CallbackTransformer(
-            fn ($data) => $data ?? [],
-            fn ($data) => array_column($data ?? [], 'value', 'key'),
+            static fn ($data) => $data ?? [],
+            static fn ($data) => array_column($data ?? [], 'value', 'key'),
         ));
     }
 

--- a/src/Form/Type/ProcessUploadFileType.php
+++ b/src/Form/Type/ProcessUploadFileType.php
@@ -25,6 +25,7 @@ class ProcessUploadFileType extends AbstractType
         $resolver->setRequired('process_code');
     }
 
+    #[\Override]
     public function getParent(): string
     {
         return FileType::class;

--- a/src/Http/Model/HttpProcessExecution.php
+++ b/src/Http/Model/HttpProcessExecution.php
@@ -20,21 +20,18 @@ use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Sequentially;
 use Symfony\Component\Validator\Constraints\Type;
 
-/**
- * PHP 8.2 : Replace by readonly class.
- */
-final class HttpProcessExecution
+final readonly class HttpProcessExecution
 {
     /**
      * @param string|array<string|int, mixed> $context
      */
     public function __construct(
         #[Sequentially(constraints: [new NotNull(message: 'Process code is required.'), new IsValidProcessCode()])]
-        public readonly ?string $code = null,
-        public readonly ?string $input = null,
+        public ?string $code = null,
+        public ?string $input = null,
         #[AtLeastOneOf(constraints: [new Json(), new Type('array')])]
-        public readonly string|array $context = [],
-        public readonly bool $queue = true,
+        public string|array $context = [],
+        public bool $queue = true,
     ) {
     }
 }

--- a/src/Http/ValueResolver/HttpProcessExecuteValueResolver.php
+++ b/src/Http/ValueResolver/HttpProcessExecuteValueResolver.php
@@ -22,13 +22,10 @@ use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\Serializer\SerializerInterface;
 
-/**
- * PHP 8.2 : Replace by readonly class.
- */
 #[AsTargetedValueResolver('http_process_execution')]
-class HttpProcessExecuteValueResolver implements ValueResolverInterface
+readonly class HttpProcessExecuteValueResolver implements ValueResolverInterface
 {
-    public function __construct(private readonly string $storageDir, private readonly SerializerInterface $serializer)
+    public function __construct(private string $storageDir, private SerializerInterface $serializer)
     {
     }
 

--- a/src/Http/ValueResolver/HttpProcessExecuteValueResolver.php
+++ b/src/Http/ValueResolver/HttpProcessExecuteValueResolver.php
@@ -25,8 +25,10 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[AsTargetedValueResolver('http_process_execution')]
 readonly class HttpProcessExecuteValueResolver implements ValueResolverInterface
 {
-    public function __construct(private string $storageDir, private SerializerInterface $serializer)
-    {
+    public function __construct(
+        private string $storageDir,
+        private SerializerInterface $serializer,
+    ) {
     }
 
     /**
@@ -34,26 +36,46 @@ readonly class HttpProcessExecuteValueResolver implements ValueResolverInterface
      */
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
-        $all = $request->request->all();
         try {
-            if ([] === $all) {
+            $hasRequestData = $request->request->count() > 0 || $request->files->count() > 0;
+
+            if (!$hasRequestData) {
+                $content = $request->getContent();
+                if (empty($content)) {
+                    return [new HttpProcessExecution()];
+                }
+
                 $httpProcessExecution = $this->serializer->deserialize(
-                    $request->getContent(),
+                    $content,
                     HttpProcessExecution::class,
                     'json'
                 );
             } else {
-                $input = $request->get('input', $request->files->get('input'));
+                $input = $request->request->get('input') ?? $request->query->get('input');
+
+                if (null === $input) {
+                    $input = $request->files->get('input');
+                }
+
                 if ($input instanceof UploadedFile) {
                     $uploadFileName = $this->storageDir.\DIRECTORY_SEPARATOR.date('YmdHis').'_'.uniqid().'_'.$input->getClientOriginalName();
                     (new Filesystem())->dumpFile($uploadFileName, $input->getContent());
                     $input = $uploadFileName;
                 }
+
+                $code = $request->request->get('code') ?? $request->query->get('code');
+                $context = $request->request->all('context');
+                if ([] === $context) {
+                    $context = $request->query->all('context');
+                }
+
+                $queue = $request->request->getBoolean('queue', true);
+
                 $httpProcessExecution = new HttpProcessExecution(
-                    $request->get('code'),
+                    (string) $code,
                     $input,
-                    $request->get('context', []),
-                    $request->request->getBoolean('queue', true),
+                    $context,
+                    $queue
                 );
             }
 

--- a/src/Http/ValueResolver/ProcessConfigurationValueResolver.php
+++ b/src/Http/ValueResolver/ProcessConfigurationValueResolver.php
@@ -20,13 +20,10 @@ use Symfony\Component\HttpKernel\Attribute\AsTargetedValueResolver;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
-/**
- * PHP 8.2 : Replace by readonly class.
- */
 #[AsTargetedValueResolver('process')]
-class ProcessConfigurationValueResolver implements ValueResolverInterface
+readonly class ProcessConfigurationValueResolver implements ValueResolverInterface
 {
-    public function __construct(private readonly ProcessConfigurationRegistry $registry)
+    public function __construct(private ProcessConfigurationRegistry $registry)
     {
     }
 
@@ -35,6 +32,6 @@ class ProcessConfigurationValueResolver implements ValueResolverInterface
      */
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
-        return [$this->registry->getProcessConfiguration($request->get('process'))];
+        return [$this->registry->getProcessConfiguration((string)$request->request->get('process'))];
     }
 }

--- a/src/Http/ValueResolver/ProcessConfigurationValueResolver.php
+++ b/src/Http/ValueResolver/ProcessConfigurationValueResolver.php
@@ -32,6 +32,6 @@ readonly class ProcessConfigurationValueResolver implements ValueResolverInterfa
      */
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
-        return [$this->registry->getProcessConfiguration((string)$request->request->get('process'))];
+        return [$this->registry->getProcessConfiguration((string) $request->request->get('process'))];
     }
 }

--- a/src/Manager/ProcessConfigurationsManager.php
+++ b/src/Manager/ProcessConfigurationsManager.php
@@ -21,9 +21,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraint;
 
 /**
- * PHP 8.2 : Replace by readonly class.
- */
-/**
  * @phpstan-type UiOptions array{
  *      'source': ?string,
  *      'target': ?string,
@@ -35,9 +32,9 @@ use Symfony\Component\Validator\Constraint;
  *      'default': array{'input': mixed, 'context': array{array{'key': 'int|text', 'value':'int|text'}}}
  *  }
  */
-final class ProcessConfigurationsManager
+readonly final class ProcessConfigurationsManager
 {
-    public function __construct(private readonly ProcessConfigurationRegistry $registry)
+    public function __construct(private ProcessConfigurationRegistry $registry)
     {
     }
 

--- a/src/Manager/ProcessConfigurationsManager.php
+++ b/src/Manager/ProcessConfigurationsManager.php
@@ -32,7 +32,7 @@ use Symfony\Component\Validator\Constraint;
  *      'default': array{'input': mixed, 'context': array{array{'key': 'int|text', 'value':'int|text'}}}
  *  }
  */
-readonly final class ProcessConfigurationsManager
+final readonly class ProcessConfigurationsManager
 {
     public function __construct(private ProcessConfigurationRegistry $registry)
     {

--- a/src/Manager/ProcessConfigurationsManager.php
+++ b/src/Manager/ProcessConfigurationsManager.php
@@ -25,7 +25,6 @@ use Symfony\Component\Validator\Constraint;
  *      'source': ?string,
  *      'target': ?string,
  *      'ui_launch_mode': ?string,
- *      'run_confirmation_modal': bool,
  *      'entrypoint_type': string,
  *      'constraints': Constraint[],
  *      'run': 'null|bool',
@@ -72,7 +71,10 @@ final readonly class ProcessConfigurationsManager
     private function resolveUiOptions(array $options): array
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefault('ui', function (OptionsResolver $uiResolver): void {
+        $resolver->setDefault('ui', []);
+        $resolver->setAllowedTypes('ui', 'array');
+        $resolver->setNormalizer('ui', function (Options $options, array $ui): array {
+            $uiResolver = new OptionsResolver();
             $uiResolver->setDefaults(
                 [
                     'source' => null,
@@ -90,15 +92,11 @@ final readonly class ProcessConfigurationsManager
                     },
                 ]
             );
-            $uiResolver->setDeprecated(
-                'run',
-                'cleverage/ui-process-bundle',
-                '2',
-                'run ui option is deprecated. Use public option instead to hide a process from UI'
-            );
             $uiResolver->setAllowedValues('entrypoint_type', ['text', 'file']);
             $uiResolver->setNormalizer('constraints', fn (Options $options, array $values): array => (new ConstraintLoader())->buildConstraints($values));
             $uiResolver->setAllowedValues('ui_launch_mode', ['modal', null, 'form']);
+
+            return $uiResolver->resolve($ui);
         });
         /**
          * @var array{'ui': UiOptions} $options

--- a/src/Manager/ProcessConfigurationsManager.php
+++ b/src/Manager/ProcessConfigurationsManager.php
@@ -40,13 +40,13 @@ final readonly class ProcessConfigurationsManager
     /** @return ProcessConfiguration[] */
     public function getPublicProcesses(): array
     {
-        return array_filter($this->getConfigurations(), fn (ProcessConfiguration $cfg) => $cfg->isPublic());
+        return array_filter($this->getConfigurations(), static fn (ProcessConfiguration $cfg) => $cfg->isPublic());
     }
 
     /** @return ProcessConfiguration[] */
     public function getPrivateProcesses(): array
     {
-        return array_filter($this->getConfigurations(), fn (ProcessConfiguration $cfg) => !$cfg->isPublic());
+        return array_filter($this->getConfigurations(), static fn (ProcessConfiguration $cfg) => !$cfg->isPublic());
     }
 
     /**
@@ -73,7 +73,7 @@ final readonly class ProcessConfigurationsManager
         $resolver = new OptionsResolver();
         $resolver->setDefault('ui', []);
         $resolver->setAllowedTypes('ui', 'array');
-        $resolver->setNormalizer('ui', function (Options $options, array $ui): array {
+        $resolver->setNormalizer('ui', static function (Options $options, array $ui): array {
             $uiResolver = new OptionsResolver();
             $uiResolver->setDefaults(
                 [
@@ -83,9 +83,9 @@ final readonly class ProcessConfigurationsManager
                     'ui_launch_mode' => 'modal',
                     'constraints' => [],
                     'run' => null,
-                    'default' => function (OptionsResolver $defaultResolver) {
+                    'default' => static function (OptionsResolver $defaultResolver) {
                         $defaultResolver->setDefault('input', null);
-                        $defaultResolver->setDefault('context', function (OptionsResolver $contextResolver) {
+                        $defaultResolver->setDefault('context', static function (OptionsResolver $contextResolver) {
                             $contextResolver->setPrototype(true);
                             $contextResolver->setRequired(['key', 'value']);
                         });
@@ -93,7 +93,7 @@ final readonly class ProcessConfigurationsManager
                 ]
             );
             $uiResolver->setAllowedValues('entrypoint_type', ['text', 'file']);
-            $uiResolver->setNormalizer('constraints', fn (Options $options, array $values): array => (new ConstraintLoader())->buildConstraints($values));
+            $uiResolver->setNormalizer('constraints', static fn (Options $options, array $values): array => (new ConstraintLoader())->buildConstraints($values));
             $uiResolver->setAllowedValues('ui_launch_mode', ['modal', null, 'form']);
 
             return $uiResolver->resolve($ui);

--- a/src/Message/CronProcessMessage.php
+++ b/src/Message/CronProcessMessage.php
@@ -15,12 +15,9 @@ namespace CleverAge\UiProcessBundle\Message;
 
 use CleverAge\UiProcessBundle\Entity\ProcessSchedule;
 
-/**
- * PHP 8.2 : Replace by readonly class.
- */
-final class CronProcessMessage
+readonly final class CronProcessMessage
 {
-    public function __construct(public readonly ProcessSchedule $processSchedule)
+    public function __construct(public ProcessSchedule $processSchedule)
     {
     }
 }

--- a/src/Message/CronProcessMessage.php
+++ b/src/Message/CronProcessMessage.php
@@ -15,7 +15,7 @@ namespace CleverAge\UiProcessBundle\Message;
 
 use CleverAge\UiProcessBundle\Entity\ProcessSchedule;
 
-readonly final class CronProcessMessage
+final readonly class CronProcessMessage
 {
     public function __construct(public ProcessSchedule $processSchedule)
     {

--- a/src/Message/CronProcessMessageHandler.php
+++ b/src/Message/CronProcessMessageHandler.php
@@ -16,13 +16,10 @@ namespace CleverAge\UiProcessBundle\Message;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-/**
- * PHP 8.2 : Replace by readonly class.
- */
 #[AsMessageHandler]
-final class CronProcessMessageHandler
+readonly final class CronProcessMessageHandler
 {
-    public function __construct(private readonly MessageBusInterface $bus)
+    public function __construct(private MessageBusInterface $bus)
     {
     }
 

--- a/src/Message/CronProcessMessageHandler.php
+++ b/src/Message/CronProcessMessageHandler.php
@@ -26,7 +26,7 @@ final readonly class CronProcessMessageHandler
     public function __invoke(CronProcessMessage $message): void
     {
         $schedule = $message->processSchedule;
-        $context = array_merge(...array_map(fn ($ctx) => [$ctx['key'] => $ctx['value']], $schedule->getContext()));
+        $context = array_merge(...array_map(static fn ($ctx) => [$ctx['key'] => $ctx['value']], $schedule->getContext()));
         $this->bus->dispatch(
             new ProcessExecuteMessage($schedule->getProcess() ?? '', $schedule->getInput(), $context)
         );

--- a/src/Message/CronProcessMessageHandler.php
+++ b/src/Message/CronProcessMessageHandler.php
@@ -17,7 +17,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
-readonly final class CronProcessMessageHandler
+final readonly class CronProcessMessageHandler
 {
     public function __construct(private MessageBusInterface $bus)
     {

--- a/src/Message/ProcessExecuteHandler.php
+++ b/src/Message/ProcessExecuteHandler.php
@@ -17,13 +17,10 @@ use CleverAge\ProcessBundle\Manager\ProcessManager;
 use CleverAge\UiProcessBundle\Monolog\Handler\ProcessHandler;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-/**
- * PHP 8.2 : Replace by readonly class.
- */
 #[AsMessageHandler]
-class ProcessExecuteHandler
+readonly class ProcessExecuteHandler
 {
-    public function __construct(private readonly ProcessManager $manager, private readonly ProcessHandler $processHandler)
+    public function __construct(private ProcessManager $manager, private ProcessHandler $processHandler)
     {
     }
 

--- a/src/Message/ProcessExecuteMessage.php
+++ b/src/Message/ProcessExecuteMessage.php
@@ -13,15 +13,12 @@ declare(strict_types=1);
 
 namespace CleverAge\UiProcessBundle\Message;
 
-/**
- * PHP 8.2 : Replace by readonly class.
- */
-class ProcessExecuteMessage
+readonly class ProcessExecuteMessage
 {
     /**
      * @param mixed[] $context
      */
-    public function __construct(public readonly string $code, public readonly mixed $input, public readonly array $context = [])
+    public function __construct(public string $code, public mixed $input, public array $context = [])
     {
     }
 }

--- a/src/Migrations/Version20231006111525.php
+++ b/src/Migrations/Version20231006111525.php
@@ -21,6 +21,7 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20231006111525 extends AbstractMigration
 {
+    #[\Override]
     public function getDescription(): string
     {
         return 'Create tables log_record, process_execution and process_user';
@@ -70,6 +71,7 @@ final class Version20231006111525 extends AbstractMigration
         }
     }
 
+    #[\Override]
     public function down(Schema $schema): void
     {
         $this->addSql('ALTER TABLE log_record DROP CONSTRAINT FK_8ECECC333DAC0075');

--- a/src/Migrations/Version20240729151928.php
+++ b/src/Migrations/Version20240729151928.php
@@ -24,6 +24,7 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20240729151928 extends AbstractMigration
 {
+    #[\Override]
     public function getDescription(): string
     {
         return 'Create table process_schedule';
@@ -41,6 +42,7 @@ final class Version20240729151928 extends AbstractMigration
         }
     }
 
+    #[\Override]
     public function down(Schema $schema): void
     {
         $this->addSql('DROP TABLE process_schedule');

--- a/src/Migrations/Version20240730090403.php
+++ b/src/Migrations/Version20240730090403.php
@@ -21,6 +21,7 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20240730090403 extends AbstractMigration
 {
+    #[\Override]
     public function getDescription(): string
     {
         return 'Add process_user.token';
@@ -31,6 +32,7 @@ final class Version20240730090403 extends AbstractMigration
         $this->addSql('ALTER TABLE process_user ADD token VARCHAR(255) DEFAULT NULL');
     }
 
+    #[\Override]
     public function down(Schema $schema): void
     {
         $this->addSql('ALTER TABLE process_user DROP token');

--- a/src/Migrations/Version20241007134542.php
+++ b/src/Migrations/Version20241007134542.php
@@ -21,6 +21,7 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20241007134542 extends AbstractMigration
 {
+    #[\Override]
     public function getDescription(): string
     {
         return 'Add process_user.timezone';
@@ -33,6 +34,7 @@ final class Version20241007134542 extends AbstractMigration
         }
     }
 
+    #[\Override]
     public function down(Schema $schema): void
     {
         if ($schema->hasTable('process_user') && $schema->getTable('process_user')->hasColumn('timezone')) {

--- a/src/Migrations/Version20241007152613.php
+++ b/src/Migrations/Version20241007152613.php
@@ -21,6 +21,7 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20241007152613 extends AbstractMigration
 {
+    #[\Override]
     public function getDescription(): string
     {
         return 'Add process_execution.context';
@@ -33,6 +34,7 @@ final class Version20241007152613 extends AbstractMigration
         }
     }
 
+    #[\Override]
     public function down(Schema $schema): void
     {
         if ($schema->hasTable('process_execution') && $schema->getTable('process_execution')->hasColumn('context')) {

--- a/src/Migrations/Version20241009075733.php
+++ b/src/Migrations/Version20241009075733.php
@@ -18,6 +18,7 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20241009075733 extends AbstractMigration
 {
+    #[\Override]
     public function getDescription(): string
     {
         return 'Add process_user.locale';
@@ -30,6 +31,7 @@ final class Version20241009075733 extends AbstractMigration
         }
     }
 
+    #[\Override]
     public function down(Schema $schema): void
     {
         if ($schema->hasTable('process_user') && $schema->getTable('process_user')->hasColumn('locale')) {

--- a/src/Monolog/Handler/DoctrineProcessHandler.php
+++ b/src/Monolog/Handler/DoctrineProcessHandler.php
@@ -50,6 +50,7 @@ class DoctrineProcessHandler extends AbstractProcessingHandler
         $this->enabled = false;
     }
 
+    #[\Override]
     public function __destruct()
     {
         $this->flush();

--- a/src/Monolog/Handler/ProcessHandler.php
+++ b/src/Monolog/Handler/ProcessHandler.php
@@ -52,6 +52,7 @@ class ProcessHandler extends StreamHandler
         $this->filenameSet = true;
     }
 
+    #[\Override]
     public function close(): void
     {
         parent::close();
@@ -63,6 +64,7 @@ class ProcessHandler extends StreamHandler
         return $this->filenameSet ? $this->url : null;
     }
 
+    #[\Override]
     protected function write(LogRecord $record): void
     {
         if (!$this->filenameSet) {

--- a/src/Monolog/Handler/ProcessHandler.php
+++ b/src/Monolog/Handler/ProcessHandler.php
@@ -21,13 +21,15 @@ use Monolog\LogRecord;
 class ProcessHandler extends StreamHandler
 {
     private Level $reportIncrementLevel = Level::Error;
+    private bool $filenameSet = false;
 
     public function __construct(
         private readonly string $directory,
         private readonly ProcessExecutionManager $processExecutionManager,
         int|string|Level $level = Level::Debug,
     ) {
-        parent::__construct($this->directory, $level);
+        // Initialize with php://memory as placeholder - actual file will be set via setFilename()
+        parent::__construct('php://memory', $level);
     }
 
     /**
@@ -40,27 +42,33 @@ class ProcessHandler extends StreamHandler
 
     public function hasFilename(): bool
     {
-        return $this->directory !== $this->url;
+        return $this->filenameSet;
     }
 
     public function setFilename(string $filename): void
     {
+        $this->close();
         $this->url = \sprintf('%s/%s', $this->directory, $filename);
+        $this->filenameSet = true;
     }
 
     public function close(): void
     {
-        $this->url = $this->directory;
         parent::close();
+        $this->filenameSet = false;
     }
 
     public function getFilename(): ?string
     {
-        return $this->url;
+        return $this->filenameSet ? $this->url : null;
     }
 
-    public function write(LogRecord $record): void
+    protected function write(LogRecord $record): void
     {
+        if (!$this->filenameSet) {
+            // Skip writing if no filename has been set yet
+            return;
+        }
         parent::write($record);
         if ($record->level->value >= $this->reportIncrementLevel->value) {
             $this->processExecutionManager->increment($record->level->name);

--- a/src/Scheduler/CronScheduler.php
+++ b/src/Scheduler/CronScheduler.php
@@ -22,15 +22,12 @@ use Symfony\Component\Scheduler\Schedule;
 use Symfony\Component\Scheduler\ScheduleProviderInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-/**
- * PHP 8.2 : Replace by readonly class.
- */
-class CronScheduler implements ScheduleProviderInterface
+readonly class CronScheduler implements ScheduleProviderInterface
 {
     public function __construct(
-        private readonly ProcessScheduleRepository $repository,
-        private readonly ValidatorInterface $validator,
-        private readonly LoggerInterface $logger,
+        private ProcessScheduleRepository $repository,
+        private ValidatorInterface $validator,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/src/Security/HttpProcessExecutionAuthenticator.php
+++ b/src/Security/HttpProcessExecutionAuthenticator.php
@@ -34,7 +34,7 @@ class HttpProcessExecutionAuthenticator extends AbstractAuthenticator
 
     public function supports(Request $request): ?bool
     {
-        return 'http_process_execute' === $request->get('_route') && $request->isMethod(Request::METHOD_POST);
+        return 'http_process_execute' === $request->request->get('_route') && $request->isMethod(Request::METHOD_POST);
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Twig/Components/BootstrapModal.php
+++ b/src/Twig/Components/BootstrapModal.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the CleverAge/UiProcessBundle package.
  *

--- a/src/Twig/Extension/LogLevelExtension.php
+++ b/src/Twig/Extension/LogLevelExtension.php
@@ -19,6 +19,7 @@ use Twig\TwigFunction;
 
 class LogLevelExtension extends AbstractExtension
 {
+    #[\Override]
     public function getFunctions(): array
     {
         return [

--- a/src/Twig/Extension/MD5Extension.php
+++ b/src/Twig/Extension/MD5Extension.php
@@ -19,6 +19,7 @@ use Twig\TwigFilter;
 
 class MD5Extension extends AbstractExtension
 {
+    #[\Override]
     public function getFilters(): array
     {
         return [

--- a/src/Twig/Extension/ProcessExecutionExtension.php
+++ b/src/Twig/Extension/ProcessExecutionExtension.php
@@ -19,6 +19,7 @@ use Twig\TwigFunction;
 
 class ProcessExecutionExtension extends AbstractExtension
 {
+    #[\Override]
     public function getFunctions(): array
     {
         return [

--- a/src/Twig/Extension/ProcessExtension.php
+++ b/src/Twig/Extension/ProcessExtension.php
@@ -19,6 +19,7 @@ use Twig\TwigFunction;
 
 class ProcessExtension extends AbstractExtension
 {
+    #[\Override]
     public function getFunctions(): array
     {
         return [

--- a/src/Twig/Runtime/ProcessExecutionExtensionRuntime.php
+++ b/src/Twig/Runtime/ProcessExecutionExtensionRuntime.php
@@ -18,14 +18,11 @@ use CleverAge\UiProcessBundle\Manager\ProcessConfigurationsManager;
 use CleverAge\UiProcessBundle\Repository\ProcessExecutionRepository;
 use Twig\Extension\RuntimeExtensionInterface;
 
-/**
- * PHP 8.2 : Replace by readonly class.
- */
-class ProcessExecutionExtensionRuntime implements RuntimeExtensionInterface
+readonly class ProcessExecutionExtensionRuntime implements RuntimeExtensionInterface
 {
     public function __construct(
-        private readonly ProcessExecutionRepository $processExecutionRepository,
-        private readonly ProcessConfigurationsManager $processConfigurationsManager,
+        private ProcessExecutionRepository $processExecutionRepository,
+        private ProcessConfigurationsManager $processConfigurationsManager,
     ) {
     }
 

--- a/src/Twig/Runtime/ProcessExtensionRuntime.php
+++ b/src/Twig/Runtime/ProcessExtensionRuntime.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the CleverAge/UiProcessBundle package.
  *

--- a/templates/admin/process/launch.html.twig
+++ b/templates/admin/process/launch.html.twig
@@ -1,5 +1,5 @@
-{% extends ea.templatePath('layout') %}
-{% trans_default_domain ea.i18n.translationDomain %}
+{% extends ea().templatePath('layout') %}
+{% trans_default_domain ea().i18n.translationDomain %}
 
 {% block main %}
     {% form_theme form '@EasyAdmin/crud/form_theme.html.twig' %}

--- a/templates/admin/process/list.html.twig
+++ b/templates/admin/process/list.html.twig
@@ -1,6 +1,6 @@
 {# @var urlGenerator \EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator #}
-{% extends ea.templatePath('layout') %}
-{% trans_default_domain ea.i18n.translationDomain %}
+{% extends ea().templatePath('layout') %}
+{% trans_default_domain ea().i18n.translationDomain %}
 
 {% block content_title %}{{ 'Processes'|trans }}{% endblock %}
 


### PR DESCRIPTION
## Description

* Bump PHP to 8.2+ and enable support for Symfony 6.4, 7.4, and 8.0 in composer.json.
* Add PHP 8.5 support in GitHub workflows and Docker configuration.
* Update PHPUnit dependencies
* Migrate from PHPDoc annotations to PHPUnit attributes in test classes.
* Update .github/workflows/test.yml and .github/workflows/quality.yml to use actions/checkout@v6.
* Adjust Rector configuration for PHP 8.5 compatibility.
* Update Dockerfile to reflect changes in PHP version and simplifications.

## Requirements

* Documentation updates
  - [ ] Reference
  - [ ] Changelog
* [ ] Unit tests 

## Breaking changes

<!-- Please list here every breaking changes this PR might induce with minor/major labels -->
